### PR TITLE
ci: run tests on push to main and tag creation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: test
 
 on:
+  push:
+    branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to run tests not only on pull requests, but also on:
- Direct pushes to the main branch
- Tag creation (v* pattern)

This ensures that CI runs for all code changes, not just those that go through the PR process.

Related to recent observation that tests weren't running on tag pushes.